### PR TITLE
feat: 訪問済みPOI管理機能を追加

### DIFF
--- a/src/app/actions/visited.ts
+++ b/src/app/actions/visited.ts
@@ -1,0 +1,114 @@
+'use server';
+
+import { VisitedRepository } from '@/repositories/visitedRepository';
+import { createPlacesRepository } from '@/repositories/placesRepository';
+import { Place } from '@/types';
+import { revalidatePath } from 'next/cache';
+
+const visitedRepository = new VisitedRepository();
+
+/**
+ * 訪問場所に追加するサーバーアクション
+ * @param placeId Google Places APIのplace_id
+ * @returns 成功時は成功メッセージ、失敗時はエラーメッセージ
+ */
+export async function addToVisited(placeId: string) {
+  try {
+    await visitedRepository.addVisitedPlace(placeId);
+    revalidatePath('/');
+    revalidatePath('/visited');
+    return { success: true, message: '訪問場所に追加しました' };
+  } catch (error) {
+    console.error('Add to visited error:', error);
+    return { 
+      success: false, 
+      message: error instanceof Error ? error.message : '訪問場所の追加に失敗しました' 
+    };
+  }
+}
+
+/**
+ * 訪問場所から削除するサーバーアクション
+ * @param placeId Google Places APIのplace_id
+ * @returns 成功時は成功メッセージ、失敗時はエラーメッセージ
+ */
+export async function removeFromVisited(placeId: string) {
+  try {
+    await visitedRepository.removeVisitedPlace(placeId);
+    revalidatePath('/');
+    revalidatePath('/visited');
+    return { success: true, message: '訪問場所から削除しました' };
+  } catch (error) {
+    console.error('Remove from visited error:', error);
+    return { 
+      success: false, 
+      message: error instanceof Error ? error.message : '訪問場所の削除に失敗しました' 
+    };
+  }
+}
+
+/**
+ * 訪問場所状態をチェックするサーバーアクション
+ * @param placeId Google Places APIのplace_id
+ * @returns 訪問場所に登録されているかの真偽値
+ */
+export async function checkVisitedStatus(placeId: string): Promise<boolean> {
+  try {
+    return await visitedRepository.isVisited(placeId);
+  } catch (error) {
+    console.error('Check visited status error:', error);
+    return false;
+  }
+}
+
+/**
+ * 訪問場所一覧とそれらの詳細情報を取得するサーバーアクション
+ * @returns 訪問場所のPlace一覧、またはエラーメッセージ
+ */
+export async function getVisitedPlaces(): Promise<{
+  success: boolean;
+  places?: Place[];
+  error?: string;
+}> {
+  try {
+    // 訪問場所一覧を取得
+    const visitedList = await visitedRepository.getVisitedPlaces();
+    
+    if (visitedList.length === 0) {
+      return { success: true, places: [] };
+    }
+
+    // Google Maps APIキーを取得
+    const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+    if (!apiKey) {
+      throw new Error('Google Maps API key is not configured');
+    }
+
+    // Places APIから詳細情報を取得
+    const placesRepository = createPlacesRepository(apiKey);
+    const placeIds = visitedList.map(visited => visited.place_id);
+    const places = await placesRepository.getPlacesDetails(placeIds);
+
+    return { success: true, places };
+  } catch (error) {
+    console.error('Failed to get visited places:', error);
+    return { 
+      success: false, 
+      error: error instanceof Error ? error.message : '訪問場所の取得に失敗しました' 
+    };
+  }
+}
+
+/**
+ * 複数のplace_idの中で訪問場所に登録されているものを取得するサーバーアクション
+ * @param placeIds place_idの配列
+ * @returns 訪問場所に登録されているplace_idの配列
+ */
+export async function getVisitedStatuses(placeIds: string[]): Promise<string[]> {
+  try {
+    return await visitedRepository.getVisitedStatuses(placeIds);
+  } catch (error) {
+    console.error('Failed to get visited statuses:', error);
+    return [];
+  }
+} 

--- a/src/app/visited/page.tsx
+++ b/src/app/visited/page.tsx
@@ -1,0 +1,98 @@
+import { getVisitedPlaces } from '@/app/actions/visited';
+import { PlaceCard } from '@/components/place';
+
+/**
+ * 訪問場所一覧ページのメタデータ
+ */
+export const metadata = {
+  title: '訪問済み | My Places',
+  description: '訪問済みに登録したPOI一覧を表示します',
+};
+
+/**
+ * 訪問場所が空の場合の表示コンポーネント
+ */
+function EmptyVisited() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="text-center py-12">
+        <div className="text-gray-400 text-6xl mb-4">✓</div>
+        <p className="text-gray-500 text-lg">
+          訪問済みの場所がまだありません
+        </p>
+        <p className="text-gray-400 mt-2">
+          場所を検索して訪問済みにマークしてみましょう
+        </p>
+        <a 
+          href="/" 
+          className="inline-block mt-6 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          場所を検索する
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * エラー表示コンポーネント
+ */
+function ErrorMessage({ error }: { error: string }) {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="text-center py-12">
+        <div className="text-red-500 text-lg font-medium">
+          エラーが発生しました
+        </div>
+        <p className="text-gray-600 mt-2">{error}</p>
+        <p className="text-gray-400 mt-2 text-sm">
+          しばらく時間をおいてから再度お試しください
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 訪問済み一覧ページ
+ */
+export default async function VisitedPage() {
+  // サーバーアクション経由で訪問済みデータを取得
+  const result = await getVisitedPlaces();
+
+  // エラー時
+  if (!result.success) {
+    return <ErrorMessage error={result.error || 'データの取得に失敗しました'} />;
+  }
+
+  const places = result.places || [];
+
+  // 訪問済みが空の場合
+  if (places.length === 0) {
+    return <EmptyVisited />;
+  }
+
+  // 訪問済み一覧を表示
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-gray-900">
+          訪問済み
+        </h1>
+        <p className="text-gray-600 mt-2">
+          訪問済みに登録したPOI一覧 ({places.length}件)
+        </p>
+      </div>
+      
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-1">
+        {places.map((place) => (
+          <PlaceCard 
+            key={place.place_id} 
+            place={place} 
+            isVisited={true}
+          />
+        ))}
+      </div>
+    </div>
+  );
+} 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,6 +32,13 @@ export function Header() {
               <span className="text-lg">❤️</span>
               お気に入り
             </Link>
+            <Link 
+              href="/visited" 
+              className="text-gray-600 hover:text-gray-900 transition-colors flex items-center gap-2"
+            >
+              <span className="text-lg">✓</span>
+              訪問済み
+            </Link>
           </nav>
         </div>
       </div>

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,6 +1,7 @@
 import { Place } from '@/types';
 import { PlaceCard } from './place';
 import { getFavoriteStatuses } from '@/app/actions/favorites';
+import { getVisitedStatuses } from '@/app/actions/visited';
 
 /**
  * 検索結果一覧を表示するコンポーネント
@@ -67,9 +68,10 @@ export async function SearchResults({ places, query, error }: SearchResultsProps
     return <NoResults query={query} />;
   }
 
-  // お気に入り状態をサーバーアクション経由で取得
+  // お気に入り状態と訪問状態をサーバーアクション経由で取得
   const placeIds = places.map(place => place.place_id);
   const favoriteStatuses = await getFavoriteStatuses(placeIds);
+  const visitedStatuses = await getVisitedStatuses(placeIds);
 
   // 検索結果を表示
   return (
@@ -91,6 +93,7 @@ export async function SearchResults({ places, query, error }: SearchResultsProps
             key={place.place_id} 
             place={place} 
             isFavorite={favoriteStatuses.includes(place.place_id)}
+            isVisited={visitedStatuses.includes(place.place_id)}
           />
         ))}
       </div>

--- a/src/components/place/PlaceCard.tsx
+++ b/src/components/place/PlaceCard.tsx
@@ -1,5 +1,6 @@
 import { Place } from '@/types';
 import { FavoriteButton } from './FavoriteButton';
+import { VisitedButton } from './VisitedButton';
 import { StarRating } from './StarRating';
 import { OpeningStatus } from './OpeningStatus';
 import { PriceLevel } from './PriceLevel';
@@ -10,16 +11,17 @@ import { PriceLevel } from './PriceLevel';
 export interface PlaceCardProps {
   place: Place;
   isFavorite?: boolean;
+  isVisited?: boolean;
 }
 
 /**
  * 場所カードコンポーネント（サーバーコンポーネント）
  */
-export function PlaceCard({ place, isFavorite = false }: PlaceCardProps) {
+export function PlaceCard({ place, isFavorite = false, isVisited = false }: PlaceCardProps) {
   return (
     <div className="bg-white rounded-lg shadow-md border border-gray-200 p-6 hover:shadow-lg transition-shadow">
       <div className="space-y-4">
-        {/* ヘッダー（場所名とお気に入りボタン） */}
+        {/* ヘッダー（場所名とボタン） */}
         <div className="flex items-start justify-between">
           <div className="flex-1">
             <h3 className="text-xl font-semibold text-gray-900">
@@ -33,7 +35,10 @@ export function PlaceCard({ place, isFavorite = false }: PlaceCardProps) {
               </div>
             )}
           </div>
-          <FavoriteButton placeId={place.place_id} isFavorite={isFavorite} />
+          <div className="flex gap-1">
+            <FavoriteButton placeId={place.place_id} isFavorite={isFavorite} />
+            <VisitedButton placeId={place.place_id} isVisited={isVisited} />
+          </div>
         </div>
 
         {/* 住所 */}

--- a/src/components/place/VisitedButton.tsx
+++ b/src/components/place/VisitedButton.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { addToVisited, removeFromVisited } from '@/app/actions/visited';
+
+/**
+ * 訪問ボタンのプロパティ
+ */
+export interface VisitedButtonProps {
+  placeId: string;
+  isVisited: boolean;
+}
+
+/**
+ * 訪問ボタンコンポーネント（クライアントコンポーネント）
+ */
+export function VisitedButton({ placeId, isVisited }: VisitedButtonProps) {
+  const [isCurrentlyVisited, setIsCurrentlyVisited] = useState(isVisited);
+  const [isPending, startTransition] = useTransition();
+
+  const handleToggleVisited = () => {
+    startTransition(async () => {
+      try {
+        if (isCurrentlyVisited) {
+          const result = await removeFromVisited(placeId);
+          if (result.success) {
+            setIsCurrentlyVisited(false);
+          }
+        } else {
+          const result = await addToVisited(placeId);
+          if (result.success) {
+            setIsCurrentlyVisited(true);
+          }
+        }
+      } catch (error) {
+        console.error('Visited toggle error:', error);
+      }
+    });
+  };
+
+  return (
+    <button
+      onClick={handleToggleVisited}
+      disabled={isPending}
+      className={`p-2 rounded-full transition-colors ${
+        isPending 
+          ? 'opacity-50 cursor-not-allowed' 
+          : 'hover:bg-gray-100'
+      } ${
+        isCurrentlyVisited 
+          ? 'text-green-500' 
+          : 'text-gray-400 hover:text-green-500'
+      }`}
+      title={isCurrentlyVisited ? '訪問済みフラグを削除' : '訪問済みにマーク'}
+    >
+      {isCurrentlyVisited ? '✓' : '○'}
+    </button>
+  );
+} 

--- a/src/components/place/index.ts
+++ b/src/components/place/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './PlaceCard';
 export * from './FavoriteButton';
+export * from './VisitedButton';
 export * from './StarRating';
 export * from './OpeningStatus';
 export * from './PriceLevel'; 

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -2,4 +2,5 @@
  * リポジトリのエクスポート
  */
 export * from './placesRepository';
-export * from './favoritesRepository'; 
+export * from './favoritesRepository';
+export * from './visitedRepository'; 

--- a/src/repositories/visitedRepository.ts
+++ b/src/repositories/visitedRepository.ts
@@ -1,0 +1,109 @@
+import { supabase } from '@/lib/supabase';
+import { Database, TablesInsert } from '@/types/supabase';
+
+type VisitedPlace = Database['public']['Tables']['visited_places']['Row'];
+type VisitedPlaceInsert = TablesInsert<'visited_places'>;
+
+/**
+ * 訪問場所管理用リポジトリクラス
+ */
+export class VisitedRepository {
+  /**
+   * 訪問場所一覧を取得
+   * @returns 訪問場所POI一覧
+   */
+  async getVisitedPlaces(): Promise<VisitedPlace[]> {
+    const { data, error } = await supabase
+      .from('visited_places')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Failed to fetch visited places:', error);
+      throw new Error('訪問場所の取得に失敗しました');
+    }
+
+    return data || [];
+  }
+
+  /**
+   * 訪問場所に追加
+   * @param placeId Google Places APIのplace_id
+   * @returns 追加された訪問場所POI
+   */
+  async addVisitedPlace(placeId: string): Promise<VisitedPlace> {
+    const insertData: VisitedPlaceInsert = {
+      place_id: placeId,
+    };
+
+    const { data, error } = await supabase
+      .from('visited_places')
+      .insert(insertData)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Failed to add visited place:', error);
+      throw new Error('訪問場所の追加に失敗しました');
+    }
+
+    return data;
+  }
+
+  /**
+   * 訪問場所から削除
+   * @param placeId Google Places APIのplace_id
+   */
+  async removeVisitedPlace(placeId: string): Promise<void> {
+    const { error } = await supabase
+      .from('visited_places')
+      .delete()
+      .eq('place_id', placeId);
+
+    if (error) {
+      console.error('Failed to remove visited place:', error);
+      throw new Error('訪問場所の削除に失敗しました');
+    }
+  }
+
+  /**
+   * 指定したplace_idが訪問場所に登録されているかチェック
+   * @param placeId Google Places APIのplace_id
+   * @returns 訪問場所に登録されている場合はtrue
+   */
+  async isVisited(placeId: string): Promise<boolean> {
+    const { data, error } = await supabase
+      .from('visited_places')
+      .select('id')
+      .eq('place_id', placeId)
+      .limit(1);
+
+    if (error) {
+      console.error('Failed to check visited status:', error);
+      return false;
+    }
+
+    return (data?.length || 0) > 0;
+  }
+
+  /**
+   * 複数のplace_idの中で訪問場所に登録されているものを取得
+   * @param placeIds Google Places APIのplace_idの配列
+   * @returns 訪問場所に登録されているplace_idの配列
+   */
+  async getVisitedStatuses(placeIds: string[]): Promise<string[]> {
+    if (placeIds.length === 0) return [];
+
+    const { data, error } = await supabase
+      .from('visited_places')
+      .select('place_id')
+      .in('place_id', placeIds);
+
+    if (error) {
+      console.error('Failed to get visited statuses:', error);
+      return [];
+    }
+
+    return data?.map(item => item.place_id) || [];
+  }
+} 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -35,6 +35,27 @@ export type Database = {
         }
         Relationships: []
       }
+      visited_places: {
+        Row: {
+          created_at: string
+          id: number
+          place_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: never
+          place_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: never
+          place_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/20250722112252_create_visited_places_table.sql
+++ b/supabase/migrations/20250722112252_create_visited_places_table.sql
@@ -1,0 +1,12 @@
+-- 訪問済みPOI情報を保存するテーブル
+CREATE TABLE IF NOT EXISTS public.visited_places (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- 主キー
+    place_id VARCHAR(255) NOT NULL UNIQUE,  -- Google Places APIのplace_id
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),  -- 作成日時
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()  -- 更新日時
+);
+
+-- updated_atの自動更新トリガーを作成
+CREATE TRIGGER update_visited_places_updated_at 
+    BEFORE UPDATE ON visited_places 
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## 概要
お気に入り機能と同様の構造で、訪問済みPOI管理機能を実装しました。

## 変更内容
- **データベース**: `visited_places` テーブルの作成
- **リポジトリ**: `VisitedRepository` クラスの実装
- **サーバーアクション**: 訪問場所の追加/削除/一覧取得
- **コンポーネント**: `VisitedButton` の実装とPlaceCardへの統合
- **ページ**: `/visited` ページの実装
- **ナビゲーション**: Headerに訪問済みリンクを追加

## 機能
- 検索結果で訪問済みフラグを設定/解除可能
- 訪問済み一覧ページで登録した場所を閲覧可能
- 訪問済み一覧ページでフラグ削除可能

## 影響範囲
- 新規機能追加のため既存機能への影響なし